### PR TITLE
Update broccoli dependency to 0.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "mkdirp": "^0.3.5",
-    "broccoli": "0.0.12",
+    "broccoli": "^0.2.3",
     "broccoli-transform": "^0.1.1"
   }
 }


### PR DESCRIPTION
Saw it was out of date and that many Broccoli plugins use it. See also: https://github.com/joliss/broccoli/pull/52
