### PR TITLE
Respect node-glob's nonegate flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ StaticCompiler.prototype.write = function (readTree, destDir) {
       var files = helpers.multiGlob(self.options.files, {
         cwd: baseDir,
         root: baseDir,
-        nomount: false
+        nomount: false,
+        nonegate: !!self.options.nonegate
       })
       for (var i = 0; i < files.length; i++) {
         mkdirp.sync(path.join(destDir, self.options.destDir, path.dirname(files[i])))


### PR DESCRIPTION
node-glob has a bug where it does not respect negation at the start of the string: https://github.com/isaacs/node-glob/issues/62

The work-around is to respect the `nonegate` flag. This fix will allow `pickFiles` to pass that option. The default is the current behavior so will not have any backwards incompatibility issues.