### PR TITLE
Add `allowEmpty` option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,14 @@ StaticCompiler.prototype.write = function (readTree, destDir) {
       }
     }
   })
+  .catch(function(error) {
+    // `helpers.multiglob` throws an error if no files are found.
+    if (self.options.allowEmpty && error.message.match(/did not match any files/)) {
+      // if allowEmpty was specified, swallow that error
+    } else {
+      throw error;
+    }
+  })
 }
 
 StaticCompiler.prototype._copy = function (sourcePath, destPath) {


### PR DESCRIPTION
If the pattern specified does not match any files, an error is thrown (from `helpers.multiglob`). This adds an option to catch that error.

Any errors not matching the specific error message from `multiglob` or if the option is not set, will be re-thrown.

Closes #7.